### PR TITLE
Fix 6530 timer semantics and bus/pin behavior

### DIFF
--- a/sim/verilator_top.v
+++ b/sim/verilator_top.v
@@ -80,7 +80,8 @@ module verilator_top (
   assign PA1 = ddra[1] ? porta_o[1] : 1'bz;
   assign PA0 = ddra[0] ? porta_o[0] : 1'bz;
 
-  assign IRQ_PB7 = irq_en ? irq : ddrb[7] ? portb_o[7]: 1'bz;
+  // PB7 as /IRQ is open-drain: pull low when asserted, release otherwise.
+  assign IRQ_PB7 = irq_en ? (irq ? 1'bz : 1'b0) : ddrb[7] ? portb_o[7]: 1'bz;
   // CS1_PB6 is an input
   assign CS2_PB5 = ddrb[5] ? portb_o[5]: 1'bz;
   assign PB4 = ddrb[4] ? portb_o[4] : 1'bz;
@@ -93,7 +94,7 @@ module verilator_top (
     porta_i[7] = !ddra[7] ? PA7 : 1'bz;
     portb_i[7] = !ddrb[7] ? IRQ_PB7: 1'bz;
     porta_i[6] = !ddra[6] ? PA6 : 1'bz;
-    //portb_i[6] = CS1_PB6;
+    portb_i[6] = CS1;  // PB6 cell is the CS1 input on the -002/-003 mask
     porta_i[5] = !ddra[5] ? PA5 : 1'bz;
     portb_i[5] = !ddrb[5] ? CS2_PB5  : 1'bz;
     porta_i[4] = !ddra[4] ? PA4 : 1'bz;

--- a/src/mcs6530.v
+++ b/src/mcs6530.v
@@ -42,7 +42,7 @@ module mcs6530 #(
   logic io_enable;
 
   always_comb begin
-    rom_enable = rst_n & !RS0 & CS1;
+    rom_enable = rst_n & !RS0 & CS1 & we_n;  // read-only: never drive DB on writes
     if (CHIP_VERSION == 2) begin
         ram_enable = rst_n & RS0 & !CS1 & A[9] & A[8] & A[7] & A[6];
         io_enable = rst_n & RS0 & !CS1 & A[9] & A[8] & ~A[7] & A[6] & ~A[2];

--- a/src/timer.v
+++ b/src/timer.v
@@ -3,83 +3,97 @@ module timer (
     input            clk,
     input            rst_n,
     input            we_n,   // RW Read high/Write low
-    input      [2:0] A,      // Address
-    input      [7:0] DI,     // Data to processor
-    output reg [7:0] DO,     // Data from processor
+    input      [2:0] A,      // {A3, A1, A0}
+    input      [7:0] DI,     // Data to 6530
+    output reg [7:0] DO,     // Data from 6530
     output reg       OE,     // Indicates data driven on DO
-    output reg       irq,
-    output reg irq_en
+    output           irq,    // /IRQ level for PB7: low while flag && irq_en
+    output reg       irq_en  // PB7 in IRQ mode (A3 of last timer read/write)
 );
 
   reg [9:0] timer_divider;
   reg [9:0] timer_count;
   reg [7:0] timer;
+  reg       flag;  // interrupt flag: bit 7 of the interrupt flag register
 
   reg [7:0] reg_data;
   reg [2:0] reg_addr;
 
+  assign irq = ~(flag & irq_en);
+
   always @(posedge clk) begin
     if (enable && rst_n) begin
-        reg_addr <= A;
-        if (we_n) begin
-            if (~A[0]) begin
-                reg_data <= timer;
-            end else begin
-                reg_data <= {irq, 7'd0};
-            end
+      reg_addr <= A;
+      if (we_n) begin
+        if (~A[0]) begin
+          reg_data <= timer;
+        end else begin
+          reg_data <= {flag, 7'd0};
         end
-     end
+      end
+    end
   end
 
   always @(negedge clk) begin
     if (~rst_n) begin
-        timer_divider <= 10'd0;
+      timer_divider <= 10'd0;
+      timer_count   <= 10'd0;
+      timer         <= 8'd0;
+      flag          <= 1'b0;
+      irq_en        <= 1'b0;
+    end else begin
+      // Free-running countdown.  The interrupt flag sets when the counter
+      // wraps 0 -> FF (N*T+1 cycles after a write of N), and the counter
+      // then decrements at /1 so software can read the overshoot in two's
+      // complement.
+      if (timer_count == timer_divider) begin
         timer_count <= 10'd0;
-        timer <= 8'd0;
-        irq <= 1'b0;
-        irq_en <= 1'b0;
-    end else begin  
-        if (enable) begin  
-            irq <= 1'b0; // interrupt is reset whenever read or written
-            irq_en <= reg_addr[2]; 
-            if (~we_n) begin
-            // write timer counter
-                timer <= DI - 1;
-                // write divider based on address lines
-                case (reg_addr[1:0])
-                    2'b00:   timer_divider <= 10'd0;
-                    2'b01:   timer_divider <= 10'd7;
-                    2'b10:   timer_divider <= 10'd63;
-                    2'b11:   timer_divider <= 10'd1023;
-                endcase
-            end
-        end
-
+        timer       <= timer - 8'd1;
         if (timer == 8'd0) begin
-            irq <= ~(irq_en & 1'b1); // trigger irq if enabled when timer reaches 0
-            timer_count <= timer_count + 1;
-        end else begin
-        // increment the count
-            timer_count <= timer_count + 1;
+          flag          <= 1'b1;
+          timer_divider <= 10'd0;
         end
-        // decrement the timer when the divider is reached
-        if (timer_count == timer_divider) begin
-            timer <= timer - 1;
-            timer_count <= 0;
+      end else begin
+        timer_count <= timer_count + 10'd1;
+      end
+
+      // Register accesses override the free-running logic above.
+      if (enable) begin
+        if (~we_n) begin
+          // Timer write: load counter, restart prescaler, clear interrupt;
+          // A1/A0 select the divider, A3 the IRQ enable.
+          timer       <= DI - 8'd1;
+          timer_count <= 10'd0;
+          flag        <= 1'b0;
+          irq_en      <= reg_addr[2];
+          case (reg_addr[1:0])
+            2'b00: timer_divider <= 10'd0;
+            2'b01: timer_divider <= 10'd7;
+            2'b10: timer_divider <= 10'd63;
+            2'b11: timer_divider <= 10'd1023;
+          endcase
+        end else if (~reg_addr[0]) begin
+          // Timer read: clear the interrupt and set the IRQ enable from A3.
+          // A read on the same edge the interrupt occurs does not clear the
+          // flag (datasheet page 10).
+          irq_en <= reg_addr[2];
+          if (!(timer_count == timer_divider && timer == 8'd0)) begin
+            flag <= 1'b0;
+          end
         end
+        // Interrupt flag register reads have no side effects.
+      end
     end
   end
-
 
   always_comb begin
     OE = 1'b0;
     DO = 8'h00;
     if (enable) begin
-        if (we_n) begin
-            {OE, DO} = {1'b1, reg_data};
-        end
+      if (we_n) begin
+        {OE, DO} = {1'b1, reg_data};
+      end
     end
   end
 
 endmodule
-

--- a/src/top.v
+++ b/src/top.v
@@ -112,6 +112,9 @@ module top (
 
 
   // Bidirectional data pins. Non-registered input, output and output enable.
+  // Drive only while PHI2 is high, like the real chip (READ timing TCDR is
+  // referenced to the positive clock transition): the bus must be free
+  // during PHI1 for other devices' turnaround.
   SB_IO #(
       .PIN_TYPE(6'b1010_01)
   ) io_data[7:0] (
@@ -119,7 +122,7 @@ module top (
 `ifdef VERILATOR
       .CLOCK_ENABLE     (1'b1),
 `endif
-      .OUTPUT_ENABLE    (OE),
+      .OUTPUT_ENABLE    (OE & phi2_io),
       .D_IN_0           (data_i),
       .D_OUT_0          (data_o)
   );

--- a/src/top.v
+++ b/src/top.v
@@ -51,11 +51,8 @@ module top (
   wire we_n;
   wire rst_n;
   wire phi2_io;
-  reg phi1_io;
-
-  always @* begin
-      phi1_io = ~phi2_io;
-  end
+  wire cs1;
+  wire irq, irq_en;
 
   wire OE;
 
@@ -114,7 +111,7 @@ module top (
 
 
 
-  // Bidirectional data pins. Registered input and output enable.
+  // Bidirectional data pins. Non-registered input, output and output enable.
   SB_IO #(
       .PIN_TYPE(6'b1010_01)
   ) io_data[7:0] (
@@ -127,7 +124,7 @@ module top (
       .D_OUT_0          (data_o)
   );
 
-  // Bidirectional io port A. Registered input and output enable.
+  // Bidirectional io port A. Non-registered input, output and output enable.
   SB_IO #(
       .PIN_TYPE(6'b1010_01),
       .PULLUP(1'b1)
@@ -141,23 +138,25 @@ module top (
       .D_OUT_0          (porta_o)
   );
 
-wire cs1;
-reg dontcare;
-reg irq, irq_en;
-
-  // Bidirectional io port B. Registered input and output enable.
+  // Bidirectional io port B.  The 6530-002/-003 mask uses the PB6 cell as
+  // the CS1 input, so there is no PB6 I/O: reading port B bit 6 returns
+  // the CS1 pin level.  PB7 doubles as the /IRQ output when enabled by
+  // A3; the datasheet specifies it only pulls low, so it is driven
+  // open-drain here to allow wire-ANDing with other interrupt sources.
   SB_IO #(
       .PIN_TYPE(6'b1010_01),
       .PULLUP(1'b1)
-  ) io_portb[7:0] (
-      .PACKAGE_PIN      ({IRQ_PB7, dontcare, CS2_PB5, PB4, PB3, PB2, PB1, PB0}),
+  ) io_portb[6:0] (
+      .PACKAGE_PIN      ({IRQ_PB7, CS2_PB5, PB4, PB3, PB2, PB1, PB0}),
 `ifdef VERILATOR
       .CLOCK_ENABLE     (1'b1),
 `endif
-      .OUTPUT_ENABLE    ({irq_en ? 1'b1: ddrb[7], ddrb[6:0]}),
-      .D_IN_0           (portb_i),
-      .D_OUT_0          ({irq_en ? irq: portb_o[7], portb_o[6:0]})
+      .OUTPUT_ENABLE    ({irq_en ? ~irq : ddrb[7], ddrb[5:0]}),
+      .D_IN_0           ({portb_i[7], portb_i[5:0]}),
+      .D_OUT_0          ({irq_en ? 1'b0 : portb_o[7], portb_o[5:0]})
   );
+
+  assign portb_i[6] = cs1;
 
 
   // Address pin inputs.
@@ -170,9 +169,6 @@ reg irq, irq_en;
 `endif
       .D_IN_0           (addr)
   );
-
-// expand this width later
-wire [2:0] chip_version;
 
   mcs6530 #(
     `ifdef MCS6530_002


### PR DESCRIPTION
This fixes several places where the gateware diverges from the 6530 datasheet (reference/mos_6530_rriot.pdf, pages 9-10), found while reviewing timer.v against the datasheet with the KIM-1 tape interface in mind.

Timer:
- Timer writes could be silently discarded: the free-running decrement runs after the register write in the same negedge block, so it won the last-assignment race whenever the prescaler expired on that edge. In /1 mode (the reset default) that is every cycle, so the first write after reset always lost. Very likely the KIM-1 cassette problem.
- The prescaler restarts on a timer write.
- The interrupt flag and the /IRQ pin level are now separate signals. Enabling IRQ with A3 no longer asserts /IRQ immediately, and the flag register reads 0x80 after timeout in IRQ-enabled mode.
- The flag sets at the 0->FF wrap (N*T+1 cycles after the write), not when the counter first reaches zero. After timeout the counter decrements at /1 regardless of the programmed divider, so reads return the elapsed overshoot in two's complement.
- Interrupt-flag register reads are side-effect free: they no longer clear the flag or rewrite the IRQ enable from A3.

Pins/bus:
- PB7 as /IRQ is open-drain (pull low only), as the datasheet describes, so it can wire-AND with other interrupt sources.
- Port B bit 6 reads the CS1 pin (the -002/-003 mask uses that cell as CS1). This removes the floating "dontcare" SB_IO, which was unconstrained and could have been placed on an arbitrary package ball.
- The data bus is driven only during PHI2 high (per the READ timing, TCDR is referenced to the positive clock transition), and never on write cycles to ROM space.

Both variants build clean with yosys/nextpnr, Fmax ~46 MHz at the 1 MHz bus clock. I have a self-checking regression testbench covering all of the above; I kept it out of this PR to keep the diff reviewable and will send it as a follow-up.

Note: check_timer in sim/verilator_driver.cpp holds the timer-read address on the bus continuously, which on a real 6530 (and now here) clears the interrupt every cycle, so its expectations likely need updating.